### PR TITLE
Use visitors PPX extension.

### DIFF
--- a/archetype.opam
+++ b/archetype.opam
@@ -31,6 +31,7 @@ depends: [
   "yojson"
   "ppx_deriving"
   "ppx_deriving_yojson"
+  "visitors"
 ]
 conflicts: [
   "digestif" {= "0.7.4"}

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,7 @@
   (name archetype)
   (public_name archetype)
   (preprocess
-    (pps ppx_deriving.std ppx_deriving_yojson)
+    (pps ppx_deriving.std ppx_deriving_yojson visitors.ppx)
   )
   (library_flags (-linkall))
   (modules tools core ident options location parseTree parser lexer symbol
@@ -18,6 +18,9 @@
   gen_why3 mlwtree printer_mlwtree
   )
   (libraries menhirLib digestif num str ppx_deriving yojson ppx_deriving_yojson.runtime)
+ (flags :standard -w -30  ; Allow sharing of record labels between distinct types.
+                  -w -7   ; Allow overridden methods between visitors-generated classes.
+                  -w -17) ; Allow visit_big_int not to be declared.
 )
 
 (executable

--- a/src/ident.ml
+++ b/src/ident.ml
@@ -1,6 +1,11 @@
 (* -------------------------------------------------------------------- *)
 type ident = string
-[@@deriving yojson, show {with_path = false}]
+[@@deriving yojson, show {with_path = false},
+ visitors { variety = "map"; name = "ident_map"; polymorphic = true },
+ visitors { variety = "iter"; name = "ident_iter"; polymorphic = true },
+ visitors { variety = "reduce"; name = "ident_reduce"; polymorphic = true },
+ visitors { variety = "reduce2"; name = "ident_reduce2"; polymorphic = true }
+]
 
 (* -------------------------------------------------------------------- *)
 let cmp_ident = (String.compare : ident -> ident -> int)

--- a/src/location.ml
+++ b/src/location.ml
@@ -10,7 +10,16 @@ type t = {
   loc_bchar : int;
   loc_echar : int;
 }
-[@@deriving yojson, show {with_path = false}]
+and 'a loced = {
+  plloc : t;
+  pldesc : 'a;
+}
+[@@deriving yojson, show {with_path = false},
+ visitors { variety = "map"; name = "location_map"; polymorphic = true },
+ visitors { variety = "iter"; name = "location_iter"; polymorphic = true },
+ visitors { variety = "reduce"; name = "location_reduce"; polymorphic = true },
+ visitors { variety = "reduce2"; name = "location_reduce2"; polymorphic = true }
+]
 
 let dummy : t = {
   loc_fname = "";
@@ -73,12 +82,6 @@ let tostring (p : t) =
     spos
 
 (* -------------------------------------------------------------------- *)
-type 'a loced = {
-  plloc : t;
-  pldesc : 'a;
-}
-[@@deriving yojson]
-
 let pp_loced pp fmt (x : 'a loced) = Format.fprintf fmt "%a" pp x.pldesc
 
 let loc    x = x.plloc

--- a/src/parseTree.ml
+++ b/src/parseTree.ml
@@ -3,61 +3,54 @@ open Ident
 open Location
 
 (* -------------------------------------------------------------------- *)
-type lident = ident loced
-[@@deriving yojson]
 
 let pp_lident fmt i = Format.fprintf fmt "%s" (unloc i)
 
+type lident = ident loced
+
 (* -------------------------------------------------------------------- *)
-type container =
+and container =
   | Collection
   | Partition
-[@@deriving yojson, show {with_path = false}]
 
-type type_r =
+and type_r =
   | Tref of lident
   | Tasset of lident
   | Tcontainer of type_t * container
   | Ttuple of type_t list
   | Toption of type_t
   | Tkeyof of type_t
-[@@deriving yojson, show {with_path = false}]
 
 and type_t = type_r loced
-[@@deriving yojson, show {with_path = false}]
 
 (* -------------------------------------------------------------------- *)
-type logical_operator =
+and logical_operator =
   | And
   | Or
   | Imply
   | Equiv
-[@@deriving yojson, show {with_path = false}]
 
-type comparison_operator =
+and comparison_operator =
   | Equal
   | Nequal
   | Gt
   | Ge
   | Lt
   | Le
-[@@deriving yojson, show {with_path = false}]
 
-type arithmetic_operator =
+and arithmetic_operator =
   | Plus
   | Minus
   | Mult
   | Div
   | Modulo
-[@@deriving yojson, show {with_path = false}]
 
-type unary_operator =
+and unary_operator =
   | Uplus
   | Uminus
   | Not
-[@@deriving yojson, show {with_path = false}]
 
-type assignment_operator =
+and assignment_operator =
   | ValueAssign
   | PlusAssign
   | MinusAssign
@@ -65,41 +58,33 @@ type assignment_operator =
   | DivAssign
   | AndAssign
   | OrAssign
-[@@deriving yojson, show {with_path = false}]
 
-type quantifier =
+and quantifier =
   | Forall
   | Exists
-[@@deriving yojson, show {with_path = false}]
 
-type operator = [
-  | `Logical of logical_operator
-  | `Cmp     of comparison_operator
-  | `Arith   of arithmetic_operator
-  | `Unary   of unary_operator
-]
-[@@deriving yojson, show {with_path = false}]
+and operator =
+  | Logical of logical_operator
+  | Cmp     of comparison_operator
+  | Arith   of arithmetic_operator
+  | Unary   of unary_operator
 
-type qualid =
+and qualid =
   | Qident of lident
   | Qdot of qualid * lident
-[@@deriving yojson, show {with_path = false}]
 
-type pattern_unloc =
+and pattern_unloc =
   | Pwild
   | Pref of lident
-[@@deriving yojson, show {with_path = false}]
 
-type pattern = pattern_unloc loced
-[@@deriving yojson, show {with_path = false}]
+and pattern = pattern_unloc loced
 
-type s_term = {
+and s_term = {
   before: bool;
   label: lident option;
 }
-[@@deriving yojson, show {with_path = false}]
 
-type expr_unloc =
+and expr_unloc =
   | Eterm         of s_term * lident
   | Eliteral      of literal
   | Earray        of expr list
@@ -127,34 +112,28 @@ type expr_unloc =
   | Ereturn       of expr
   | Eoption       of option_
   | Einvalid
-[@@deriving yojson, show {with_path = false}]
 
 and branch = (pattern list * expr)
 
-and scope = [
-  | `Added
-  | `After
-  | `Before
-  | `Fixed
-  | `Removed
-  | `Stable
-]
-[@@derive yojson, show {with_path = false}]
+and scope =
+  | Added
+  | After
+  | Before
+  | Fixed
+  | Removed
+  | Stable
 
 and quantifier_kind =
   | Qcollection of expr
   | Qtype of type_t
-[@@deriving yojson, show {with_path = false}]
 
 and option_ =
   | OSome of expr
   | ONone
-[@@deriving yojson, show {with_path = false}]
 
 and function_ =
   | Fident of lident
   | Foperator of operator loced
-[@@deriving yojson, show {with_path = false}]
 
 and literal =
   | Lnumber   of Core.big_int
@@ -167,15 +146,12 @@ and literal =
   | Lbool     of bool
   | Lduration of string
   | Ldate     of string
-[@@deriving yojson, show {with_path = false}]
 
 and record_item = (assignment_operator * lident) option * expr
 
 and expr = expr_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
 and lident_typ = lident * type_t * extension list option
-[@@deriving yojson, show {with_path = false}]
 
 and label_expr = (lident * expr) loced
 
@@ -184,29 +160,22 @@ and label_exprs = label_expr list
 (* -------------------------------------------------------------------- *)
 and extension_unloc =
   | Eextension of lident * expr option (** extension *)
-[@@deriving yojson, show {with_path = false}]
 
 and extension = extension_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
 and exts = extension list option
-[@@deriving yojson, show {with_path = false}]
 
 (* -------------------------------------------------------------------- *)
-type field_unloc =
+and field_unloc =
   | Ffield of lident * type_t * expr option * exts   (** field *)
-[@@deriving yojson, show {with_path = false}]
 
 and field = field_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
-type args = lident_typ list
-[@@deriving yojson, show {with_path = false}]
+and args = lident_typ list
 
-type invariants = (lident * expr list) list
-[@@deriving yojson, show {with_path = false}]
+and invariants = (lident * expr list) list
 
-type specification_item_unloc =
+and specification_item_unloc =
   | Vpredicate of lident * args * expr
   | Vdefinition of lident * type_t * lident * expr
   | Vlemma of lident * expr
@@ -215,51 +184,40 @@ type specification_item_unloc =
   | Veffect of expr
   | Vassert of (lident * expr * invariants * lident list)
   | Vpostcondition of (lident * expr * invariants * lident list)
-[@@deriving yojson, show {with_path = false}]
 
-type specification_item = specification_item_unloc loced
-[@@deriving yojson, show {with_path = false}]
+and specification_item = specification_item_unloc loced
 
-type specification_unloc = specification_item list * exts
-[@@deriving yojson, show {with_path = false}]
+and specification_unloc = specification_item list * exts
 
-type specification = specification_unloc loced
-[@@deriving yojson, show {with_path = false}]
+and specification = specification_unloc loced
 
-type security_arg_unloc =
+and security_arg_unloc =
   | Sident of lident
   | Sdot   of lident * lident
   | Slist of security_arg list
   | Sapp of lident * security_arg list
   | Sbut of lident * security_arg
   | Sto of lident * security_arg
-[@@deriving yojson, show {with_path = false}]
 
 and security_arg = security_arg_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
-type security_item_unloc = lident * lident * security_arg list
-[@@deriving yojson, show {with_path = false}]
+and security_item_unloc = lident * lident * security_arg list
 
-type security_item = security_item_unloc loced
-[@@deriving yojson, show {with_path = false}]
+and security_item = security_item_unloc loced
 
-type security_unloc = security_item list * exts
-[@@deriving yojson, show {with_path = false}]
+and security_unloc = security_item list * exts
 
 and security = security_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
-type s_function = {
+and s_function = {
   name  : lident;
   args  : args;
   ret_t : type_t option;
   spec : specification option;
   body  : expr;
 }
-[@@deriving yojson, show {with_path = false}]
 
-type action_properties = {
+and action_properties = {
   accept_transfer : bool;
   calledby        : (expr * exts) option;
   require         : (label_exprs * exts) option;
@@ -267,24 +225,20 @@ type action_properties = {
   spec            : specification option;
   functions       : (s_function loced) list;
 }
-[@@deriving yojson, show {with_path = false}]
 
-type transition = (lident * (expr * exts) option * (expr * exts) option) list
-[@@deriving yojson, show {with_path = false}]
+and transition = (lident * (expr * exts) option * (expr * exts) option) list
 
 (* -------------------------------------------------------------------- *)
-type variable_kind =
+and variable_kind =
   | VKvariable
   | VKconstant
-[@@deriving yojson, show {with_path = false}]
 
-type enum_kind =
+and enum_kind =
   | EKenum of lident
   | EKstate
-[@@deriving yojson, show {with_path = false}]
 
 (* -------------------------------------------------------------------- *)
-type declaration_unloc =
+and declaration_unloc =
   | Darchetype     of lident * exts
   | Dvariable      of variable_decl
   | Denum          of enum_kind * enum_decl
@@ -298,7 +252,6 @@ type declaration_unloc =
   | Dspecification of specification
   | Dsecurity      of security
   | Dinvalid
-[@@deriving yojson, show {with_path = false}]
 
 and variable_decl =
   lident
@@ -347,49 +300,46 @@ and namespace_decl =
 and value_option =
   | VOfrom of lident
   | VOto of lident
-[@@deriving yojson, show {with_path = false}]
 
 and asset_option =
   | AOidentifiedby of lident
   | AOsortedby of lident
-[@@deriving yojson, show {with_path = false}]
 
 and asset_post_option =
   | APOstates of lident
   | APOconstraints of label_exprs
   | APOinit of expr
-[@@deriving yojson, show {with_path = false}]
 
 and enum_option =
   | EOinitial
   | EOspecification of label_exprs
-[@@deriving yojson, show {with_path = false}]
 
 and signature =
   | Ssignature of lident * type_t list
-[@@deriving yojson, show {with_path = false}]
 
 and declaration = declaration_unloc loced
-[@@deriving yojson, show {with_path = false}]
 
 and asset_operation_enum =
   | AOadd
   | AOremove
   | AOupdate
-[@@deriving yojson, show {with_path = false}]
 
 and asset_operation =
   | AssetOperation of asset_operation_enum list * expr option
-[@@deriving yojson, show {with_path = false}]
 
 (* -------------------------------------------------------------------- *)
-type archetype_unloc =
+and archetype_unloc =
   | Marchetype of declaration list
   | Mextension of lident * declaration list * declaration list
-[@@deriving yojson, show {with_path = false}]
 
 and archetype = archetype_unloc loced
-[@@deriving yojson, show {with_path = false}]
+[@@deriving yojson, show {with_path = false},
+ visitors { variety = "map"; ancestors = ["location_map"; "ident_map"] },
+ visitors { variety = "iter"; ancestors = ["location_iter"; "ident_iter"] },
+ visitors { variety = "reduce"; ancestors = ["location_reduce"; "ident_reduce"] },
+ visitors { variety = "reduce2"; ancestors = ["location_reduce2"; "ident_reduce2"] }
+]
+
 
 let mk_archetype ?(decls=[]) ?(loc=dummy) () =
   mkloc loc (Marchetype decls)

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -739,8 +739,10 @@ order_operations:
   | ops=loc(order_operations) op=loc(ordering_operator) e=expr
     {
       match unloc ops with
-      | Eapp (Foperator ({pldesc = `Cmp opa; plloc = lo}), [lhs; rhs]) -> Emulticomp (lhs, [mkloc lo opa, rhs; op, e])
-      | Emulticomp (a, l) -> Emulticomp (a, l @ [op, e])
+      | Eapp (Foperator ({pldesc = Cmp opa; plloc = lo}), [lhs; rhs]) ->
+	 Emulticomp (lhs, [mkloc lo opa, rhs; op, e])
+      | Emulticomp (a, l) ->
+	 Emulticomp (a, l @ [op, e])
       | _ -> assert false
     }
 
@@ -863,15 +865,15 @@ record_item:
  | NOT     { Not }
 
 %inline bin_operator:
-| op=logical_operator    { `Logical op }
-| op=comparison_operator { `Cmp op }
-| op=arithmetic_operator { `Arith op }
+| op=logical_operator    { Logical op }
+| op=comparison_operator { Cmp op }
+| op=arithmetic_operator { Arith op }
 
 %inline un_operator:
-| op=unary_operator      { `Unary op }
+| op=unary_operator      { Unary op }
 
 %inline ord_operator:
-| op=ordering_operator   { `Cmp op }
+| op=ordering_operator   { Cmp op }
 
 %inline asset_operation_enum:
 | AT_ADD    { AOadd }

--- a/src/printer_pt.ml
+++ b/src/printer_pt.ml
@@ -53,24 +53,24 @@ let e_simple        =  (150, NonAssoc) (* ?  *)
 
 let get_prec_from_operator (op : operator) =
   match op with
-  | `Logical And     -> e_and
-  | `Logical Or      -> e_or
-  | `Logical Imply   -> e_imply
-  | `Logical Equiv   -> e_equiv
-  | `Cmp Equal       -> e_equal
-  | `Cmp Nequal      -> e_nequal
-  | `Cmp Gt          -> e_gt
-  | `Cmp Ge          -> e_ge
-  | `Cmp Lt          -> e_lt
-  | `Cmp Le          -> e_le
-  | `Arith Plus      -> e_plus
-  | `Arith Minus     -> e_minus
-  | `Arith Mult      -> e_mult
-  | `Arith Div       -> e_div
-  | `Arith Modulo    -> e_modulo
-  | `Unary Uplus     -> e_plus
-  | `Unary Uminus    -> e_minus
-  | `Unary Not       -> e_not
+  | Logical And     -> e_and
+  | Logical Or      -> e_or
+  | Logical Imply   -> e_imply
+  | Logical Equiv   -> e_equiv
+  | Cmp Equal       -> e_equal
+  | Cmp Nequal      -> e_nequal
+  | Cmp Gt          -> e_gt
+  | Cmp Ge          -> e_ge
+  | Cmp Lt          -> e_lt
+  | Cmp Le          -> e_le
+  | Arith Plus      -> e_plus
+  | Arith Minus     -> e_minus
+  | Arith Mult      -> e_mult
+  | Arith Div       -> e_div
+  | Arith Modulo    -> e_modulo
+  | Unary Uplus     -> e_plus
+  | Unary Uminus    -> e_minus
+  | Unary Not       -> e_not
 
 let get_prec_from_assignment_operator (op : assignment_operator) =
   match op with
@@ -166,10 +166,10 @@ let unary_operator_to_str op =
 
 let operator_to_str op =
   match op with
-  | `Logical o -> logical_operator_to_str o
-  | `Cmp o     -> comparison_operator_to_str o
-  | `Arith o   -> arithmetic_operator_to_str o
-  | `Unary o   -> unary_operator_to_str o
+  | Logical o -> logical_operator_to_str o
+  | Cmp o     -> comparison_operator_to_str o
+  | Arith o   -> arithmetic_operator_to_str o
+  | Unary o   -> unary_operator_to_str o
 
 let pp_operator fmt op =
   Format.fprintf fmt "%s" (operator_to_str op)
@@ -221,12 +221,12 @@ let pp_pattern fmt p =
 
 let string_of_scope (s : scope) =
   match s with
-  | `Added   -> "added"
-  | `After   -> "after"
-  | `Before  -> "before"
-  | `Fixed   -> "fixed"
-  | `Removed -> "removed"
-  | `Stable  -> "stable"
+  | Added   -> "added"
+  | After   -> "after"
+  | Before  -> "before"
+  | Fixed   -> "fixed"
+  | Removed -> "removed"
+  | Stable  -> "stable"
 
 let rec pp_expr outer pos fmt a =
   let e = unloc a in

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -178,24 +178,24 @@ type error = L.t * error_desc
 let pp_operator fmt (op : PT.operator) : unit =
   let pp = Printer_tools.pp_str fmt in
   match op with
-  | `Logical And   -> pp "and"
-  | `Logical Or    -> pp "or"
-  | `Logical Imply -> pp "->"
-  | `Logical Equiv -> pp "<->"
-  | `Cmp Equal     -> pp "="
-  | `Cmp Nequal    -> pp "<>"
-  | `Cmp Gt        -> pp ">"
-  | `Cmp Ge        -> pp ">="
-  | `Cmp Lt        -> pp "<"
-  | `Cmp Le        -> pp "<="
-  | `Arith Plus    -> pp "+"
-  | `Arith Minus   -> pp "-"
-  | `Arith Mult    -> pp "*"
-  | `Arith Div     -> pp "/"
-  | `Arith Modulo  -> pp "%"
-  | `Unary Uplus   -> pp "unary +"
-  | `Unary Uminus  -> pp "unary -"
-  | `Unary Not     -> pp "not"
+  | Logical And   -> pp "and"
+  | Logical Or    -> pp "or"
+  | Logical Imply -> pp "->"
+  | Logical Equiv -> pp "<->"
+  | Cmp Equal     -> pp "="
+  | Cmp Nequal    -> pp "<>"
+  | Cmp Gt        -> pp ">"
+  | Cmp Ge        -> pp ">="
+  | Cmp Lt        -> pp "<"
+  | Cmp Le        -> pp "<="
+  | Arith Plus    -> pp "+"
+  | Arith Minus   -> pp "-"
+  | Arith Mult    -> pp "*"
+  | Arith Div     -> pp "/"
+  | Arith Modulo  -> pp "%"
+  | Unary Uplus   -> pp "unary +"
+  | Unary Uminus  -> pp "unary -"
+  | Unary Not     -> pp "not"
 
 
 (* -------------------------------------------------------------------- *)
@@ -342,42 +342,42 @@ let rgtypes =
 let cmpsigs : (PT.operator * (M.vtyp list * M.vtyp)) list =
   let ops  = [PT.Gt; PT.Ge; PT.Lt; PT.Le] in
   let sigs = List.map (fun ty -> ([ty; ty], M.VTbool)) cmptypes in
-  List.mappdt (fun op sig_ -> (`Cmp op, sig_)) ops sigs
+  List.mappdt (fun op sig_ -> (PT.Cmp op, sig_)) ops sigs
 
 let opsigs =
   let eqsigs : (PT.operator * (M.vtyp list * M.vtyp)) list =
     let ops  = [PT.Equal; PT.Nequal] in
     let sigs = List.map (fun ty -> ([ty; ty], M.VTbool)) eqtypes in
-    List.mappdt (fun op sig_ -> (`Cmp op, sig_)) ops sigs in
+    List.mappdt (fun op sig_ -> (PT.Cmp op, sig_)) ops sigs in
 
   let grptypes : (PT.operator * (M.vtyp list * M.vtyp)) list =
     let ops  =
-      (List.map (fun x -> `Arith x) [PT.Plus ; PT.Minus])
-      @ (List.map (fun x -> `Unary x) [PT.Uplus; PT.Uminus]) in
+      (List.map (fun x -> PT.Arith x) [PT.Plus ; PT.Minus])
+      @ (List.map (fun x -> PT.Unary x) [PT.Uplus; PT.Uminus]) in
     let sigs = List.map (fun ty -> ([ty; ty], ty)) grptypes in
     List.mappdt (fun op sig_ -> (op, sig_)) ops sigs in
 
   let rgtypes : (PT.operator * (M.vtyp list * M.vtyp)) list =
     let ops  =
-      (List.map (fun x -> `Arith x) [PT.Plus; PT.Minus; PT.Mult; PT.Div])
-      @ (List.map (fun x -> `Unary x) [PT.Uplus; PT.Uminus]) in
+      (List.map (fun x -> PT.Arith x) [PT.Plus; PT.Minus; PT.Mult; PT.Div])
+      @ (List.map (fun x -> PT.Unary x) [PT.Uplus; PT.Uminus]) in
     let sigs = List.map (fun ty -> ([ty; ty], ty)) rgtypes in
     List.mappdt (fun op sig_ -> (op, sig_)) ops sigs in
 
   let ariths : (PT.operator * (M.vtyp list * M.vtyp)) list =
-    [`Arith PT.Modulo, ([M.VTint; M.VTint], M.VTint)] in
+    [ PT.Arith PT.Modulo, ([M.VTint; M.VTint], M.VTint)] in
 
   let bools : (PT.operator * (M.vtyp list * M.vtyp)) list =
-    let unas = List.map (fun x -> `Unary   x) [PT.Not] in
-    let bins = List.map (fun x -> `Logical x) [PT.And; PT.Or; PT.Imply; PT.Equiv] in
+    let unas = List.map (fun x -> PT.Unary   x) [PT.Not] in
+    let bins = List.map (fun x -> PT.Logical x) [PT.And; PT.Or; PT.Imply; PT.Equiv] in
 
     List.map (fun op -> (op, ([M.VTbool], M.VTbool))) unas
     @ List.map (fun op -> (op, ([M.VTbool; M.VTbool], M.VTbool))) bins in
 
   let others : (PT.operator * (M.vtyp list * M.vtyp)) list =
-    [ `Arith PT.Plus, ([M.VTdate    ; M.VTduration      ], M.VTdate)             ;
-      `Arith PT.Plus, ([M.VTint     ; M.VTduration      ], M.VTduration)         ;
-      `Arith PT.Mult, ([M.VTrational; M.VTcurrency      ], M.VTcurrency       )  ] in
+    [ PT.Arith PT.Plus, ([M.VTdate    ; M.VTduration      ], M.VTdate)             ;
+      PT.Arith PT.Plus, ([M.VTint     ; M.VTduration      ], M.VTduration)         ;
+      PT.Arith PT.Mult, ([M.VTrational; M.VTcurrency      ], M.VTcurrency       )  ] in
 
   eqsigs @ cmpsigs @ grptypes @ rgtypes @ ariths @ bools @ others
 
@@ -1390,7 +1390,7 @@ let rec for_xexpr (mode : emode_t) (env : env) ?(ety : M.ptyp option) (tope : PT
                 Option.map (fun sig_ ->
                   let term = M.Pcomp (tt_cmp_operator op, e, e') in
                   mk_sp (Some sig_.osl_ret) term
-                ) (select_operator env (loc tope) (`Cmp op, [ty; ty']))
+                ) (select_operator env (loc tope) (PT.Cmp op, [ty; ty']))
               in (e', aout)
             end
 
@@ -1423,11 +1423,11 @@ let rec for_xexpr (mode : emode_t) (env : env) ?(ety : M.ptyp option) (tope : PT
 
         let aout =
           match op with
-          | `Logical op ->
+          | Logical op ->
             let a1, a2 = Option.get (List.as_seq2 args) in
             M.Plogical (tt_logical_operator op, a1, a2)
 
-          | `Unary op -> begin
+          | Unary op -> begin
               let a1 = Option.get (List.as_seq1 args) in
 
               match
@@ -1443,11 +1443,11 @@ let rec for_xexpr (mode : emode_t) (env : env) ?(ety : M.ptyp option) (tope : PT
                 M.Puarith (op, a1)
             end
 
-          | `Arith op ->
+          | Arith op ->
             let a1, a2 = Option.get (List.as_seq2 args) in
             M.Parith (tt_arith_operator op, a1, a2)
 
-          | `Cmp op ->
+          | Cmp op ->
             let a1, a2 = Option.get (List.as_seq2 args) in
             M.Pcomp (tt_cmp_operator op, a1, a2)
 
@@ -2559,7 +2559,7 @@ let rec for_callby (env : env) (cb : PT.expr) =
   | Eterm ({ before = false; label = None; }, name) ->
     Option.get_as_list (for_role env name)
 
-  | Eapp (Foperator { pldesc = `Logical Or }, [e1; e2]) ->
+  | Eapp (Foperator { pldesc = Logical Or }, [e1; e2]) ->
     (for_callby env e1) @ (for_callby env e2)
 
   | _ ->


### PR DESCRIPTION
This PR introduces a dependency to the [visitors PPX extension of François Pottier](https://gitlab.inria.fr/fpottier/visitors).

This PPX extension generates convenient classes of objects to implement datatype traversals where most of the cases are canonical (i.e. just perform recursive calls).

To use this extension, I had to rephrase a little bit type definitions of ParseTree by:
1. making them mutually recursive ;
2. removing the polymorphic variants.

Please tell me if these two changes are problematic.

Notice also that the compilation time of ParseTree is increased because of the amount of generated code produced by visitors.
