### PR TITLE
Fix a bug in PureLexer.initialize.

### DIFF
--- a/src/pureLexer.ml
+++ b/src/pureLexer.ml
@@ -1,4 +1,3 @@
-
 open Parser
 open Parser.MenhirInterpreter
 
@@ -24,6 +23,8 @@ end = struct
   let more = ref (fun () -> assert false)
 
   let initialize lexbuf =
+    buffer := [];
+    size := 0;
     more := lexer_lexbuf_to_supplier Lexer.token lexbuf
 
   type t = int


### PR DESCRIPTION
The state of PureLexer was not appropriately initialized. 

This lead to inconsistencies when calling IO.parse multiple times. 